### PR TITLE
Fix lockouts

### DIFF
--- a/src/Repositories/ProductErrorsRepository.php
+++ b/src/Repositories/ProductErrorsRepository.php
@@ -69,10 +69,7 @@ class ProductErrorsRepository
      */
     public function getLockedProductIds(): array
     {
-        return DB::get_col(DB::prepare(
-            "SELECT product_id FROM {$this->getTableName()} WHERE permanently_locked = 0 AND locked_until IS NOT NULL AND locked_until <= %s",
-            $this->getNow()
-        ));
+        return DB::get_col("SELECT product_id FROM {$this->getTableName()}");
     }
 
     /**

--- a/src/Repositories/ProductErrorsRepository.php
+++ b/src/Repositories/ProductErrorsRepository.php
@@ -93,23 +93,23 @@ class ProductErrorsRepository
              * :eyeroll:
              */
             if (is_null($product->getLockedUntil())) {
-                $statement = DB::prepare(
-                    "(%s, %d, null, %s)",
+                $query = "(%s, %d, null, %s)";
+                $args  = [
                     $product->productId,
                     (int) $product->isPermanentlyLocked(),
                     $product->responseBody
-                );
+                ];
             } else {
-                $statement = DB::prepare(
-                    "(%s, %d, %s, %s)",
+                $query = "(%s, %d, %s, %s)";
+                $args  = [
                     $product->productId,
                     (int) $product->isPermanentlyLocked(),
                     $product->getLockedUntil(),
                     $product->responseBody
-                );
+                ];
             }
 
-            $values[] = $statement;
+            $values[] = DB::prepare($query, ...$args);
         }
 
         return $values;

--- a/tests/Unit/Repositories/ProductErrorsRepositoryTest.php
+++ b/tests/Unit/Repositories/ProductErrorsRepositoryTest.php
@@ -175,8 +175,10 @@ class ProductErrorsRepositoryTest extends TestCase
      */
     public function testCanLockProducts(): void
     {
-        $repository   = $this->createPartialMock(ProductErrorsRepository::class,
-            ['makeLockProductStrings', 'getTableName']);
+        $repository   = $this->createPartialMock(
+            ProductErrorsRepository::class,
+            ['makeLockProductStrings', 'getTableName']
+        );
         $consequences = [new ErrorConsequence('pid', ErrorConsequence::ValidationError)];
 
         $repository->expects($this->once())

--- a/tests/Unit/Repositories/ProductErrorsRepositoryTest.php
+++ b/tests/Unit/Repositories/ProductErrorsRepositoryTest.php
@@ -46,7 +46,8 @@ class ProductErrorsRepositoryTest extends TestCase
 
         $this->mockStaticMethod(DB::class, '__callStatic')
             ->once()
-            ->with('query', ["DELETE FROM wp_contextwp_table WHERE locked_until IS NOT NULL AND locked_until < '2022-04-10 12:57:00'"])
+            ->with('query',
+                ["DELETE FROM wp_contextwp_table WHERE locked_until IS NOT NULL AND locked_until < '2022-04-10 12:57:00'"])
             ->andReturnNull();
 
         $repository->deleteExpiredErrors();
@@ -92,20 +93,36 @@ class ProductErrorsRepositoryTest extends TestCase
         $consequence->reason       = $consequenceReason;
         $consequence->responseBody = $consequenceBody;
 
-        $consequence->expects($this->once())
+        $consequence->expects($this->atLeastOnce())
             ->method('getLockedUntil')
             ->willReturn($consequenceLockedUntil);
 
-        $this->mockStaticMethod(DB::class, 'prepare')
-            ->once()
-            ->with(
+        if (is_null($consequenceLockedUntil)) {
+            $prepareArgs = [
+                "(%s, %d, null, %s)",
+                $consequence->productId,
+                (int) $consequence->isPermanentlyLocked(),
+                $consequence->responseBody
+            ];
+
+            $returnClosure = function ($string, $pid, $isLocked, $response) {
+                return sprintf(
+                    $string,
+                    $pid,
+                    $isLocked,
+                    is_null($response) ? 'null' : $response
+                );
+            };
+        } else {
+            $prepareArgs = [
                 "(%s, %d, %s, %s)",
                 $consequence->productId,
                 (int) $consequence->isPermanentlyLocked(),
                 $consequenceLockedUntil,
                 $consequence->responseBody
-            )
-            ->andReturnUsing(function ($string, $pid, $isLocked, $lockedUntil, $response) {
+            ];
+
+            $returnClosure = function ($string, $pid, $isLocked, $lockedUntil, $response) {
                 return sprintf(
                     $string,
                     $pid,
@@ -113,7 +130,13 @@ class ProductErrorsRepositoryTest extends TestCase
                     is_null($lockedUntil) ? 'null' : $lockedUntil,
                     is_null($response) ? 'null' : $response
                 );
-            });
+            };
+        }
+
+        $this->mockStaticMethod(DB::class, 'prepare')
+            ->once()
+            ->with(...$prepareArgs)
+            ->andReturnUsing($returnClosure);
 
         $this->assertEqualsCanonicalizing(
             $expected,
@@ -150,7 +173,8 @@ class ProductErrorsRepositoryTest extends TestCase
      */
     public function testCanLockProducts(): void
     {
-        $repository   = $this->createPartialMock(ProductErrorsRepository::class, ['makeLockProductStrings', 'getTableName']);
+        $repository   = $this->createPartialMock(ProductErrorsRepository::class,
+            ['makeLockProductStrings', 'getTableName']);
         $consequences = [new ErrorConsequence('pid', ErrorConsequence::ValidationError)];
 
         $repository->expects($this->once())

--- a/tests/Unit/Repositories/ProductErrorsRepositoryTest.php
+++ b/tests/Unit/Repositories/ProductErrorsRepositoryTest.php
@@ -46,8 +46,10 @@ class ProductErrorsRepositoryTest extends TestCase
 
         $this->mockStaticMethod(DB::class, '__callStatic')
             ->once()
-            ->with('query',
-                ["DELETE FROM wp_contextwp_table WHERE locked_until IS NOT NULL AND locked_until < '2022-04-10 12:57:00'"])
+            ->with(
+                'query',
+                ["DELETE FROM wp_contextwp_table WHERE locked_until IS NOT NULL AND locked_until < '2022-04-10 12:57:00'"]
+            )
             ->andReturnNull();
 
         $repository->deleteExpiredErrors();

--- a/tests/Unit/Repositories/ProductErrorsRepositoryTest.php
+++ b/tests/Unit/Repositories/ProductErrorsRepositoryTest.php
@@ -58,29 +58,17 @@ class ProductErrorsRepositoryTest extends TestCase
      */
     public function testCanGetLockedProductIds(): void
     {
-        $repository = $this->createPartialMock(ProductErrorsRepository::class, ['getNow', 'getTableName']);
+        $repository = $this->createPartialMock(ProductErrorsRepository::class, ['getTableName']);
 
         $repository->expects($this->once())
             ->method('getTableName')
             ->willReturn('wp_contextwp_table');
 
-        $repository->expects($this->once())
-            ->method('getNow')
-            ->willReturn('2022-04-10 12:57:00');
-
-        $this->mockStaticMethod(DB::class, 'prepare')
-            ->once()
-            ->with(
-                "SELECT product_id FROM wp_contextwp_table WHERE permanently_locked = 0 AND locked_until IS NOT NULL AND locked_until <= %s",
-                '2022-04-10 12:57:00'
-            )
-            ->andReturn("SELECT product_id FROM wp_contextwp_table WHERE permanently_locked = 0 AND locked_until IS NOT NULL AND locked_until <= '2022-04-10 12:57:00'");
-
         $this->mockStaticMethod(DB::class, '__callStatic')
             ->once()
             ->with(
                 'get_col',
-                ["SELECT product_id FROM wp_contextwp_table WHERE permanently_locked = 0 AND locked_until IS NOT NULL AND locked_until <= '2022-04-10 12:57:00'"]
+                ["SELECT product_id FROM wp_contextwp_table"]
             )
             ->andReturn(['id-1', 'id-2']);
 


### PR DESCRIPTION
- ProductNotFound errors were not getting permanently locked.
- Lockouts with a `null` date were getting inserted with an empty string instead of `null` (resulting in the above).
- Because we wipe all irrelevant errors prior to retrieving the IDs, the `getLockedProductIds()` method now just returns the IDs of all records.